### PR TITLE
Use the oVirt REST API to find out the guest IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Vagrant.configure('2') do |config|
     ovirt.username = 'username'
     ovirt.password = 'password'
     ovirt.datacenter = 'datacenter'
-    #ovirt.ip_command = 'echo ipaddress'
   end
 
 
@@ -72,8 +71,6 @@ This provider exposes quite a few provider-specific configuration options:
 * `password` - Password to access oVirt.
 * `datacenter` - oVirt datacenter name, where machines will be created.
 * `cluster` - oVirt cluster name. Defaults to first cluster found.
-* `ip_command` - Shell command, which shoud return IP address string for
- MAC address specified as the first parameter in the call.
 
 ### Domain Specific Options
 
@@ -148,7 +145,6 @@ Vagrant.configure('2') do |config|
     ovirt.username = 'username'
     ovirt.password = 'password'
     ovirt.datacenter = 'datacenter'
-    #ovirt.ip_command = 'echo ipaddress'
   end
 
   config.vm.provision 'shell' do |shell|
@@ -172,7 +168,7 @@ Vagrant goes through steps below when creating new project:
 1.	Connect to oVirt via REST API on every REST query.
 2.	Create new oVirt machine from template with additional network interfaces.
 3.	Start oVirt machine.
-4.	Check for IP address of VM with `ip_command`.
+4.	Check for IP address of VM using the REST API.
 5.	Wait till SSH is available.
 6.	Sync folders via `rsync` and run Vagrant provisioner on new domain if
 	setup in Vagrantfile.
@@ -202,14 +198,8 @@ dynamically via dhcp.
 
 ## Obtaining Domain IP Address
 
-OVirt API doesn't provide standard way how to find out an IP address of running
-VM. But we know, what is MAC address of virtual machine. Problem is, where to
-get mapping MAC to IP address.
-
-There is an option named ip_command, which by default looks into local arp
-table and searches there IP for MAC address specified as a MAC shell variable.
-Maybe you need to customize this behaviour, so setup your own ip_commands to
-your needs.
+The IP address of a running VM can be obtained using the oVirt REST API.
+To make this possible the package 'ovirt-guest-agent' needs to be installed in the box image.
 
 ## Synced Folders
 

--- a/lib/vagrant-ovirt/action/read_ssh_info.rb
+++ b/lib/vagrant-ovirt/action/read_ssh_info.rb
@@ -34,20 +34,7 @@ module VagrantPlugins
             return nil
           end
 
-          # oVirt doesn't provide a way how to find out IP of VM via API.
-          # IP command should return IP address of MAC defined as a shell
-          # variable.
-          # TODO place code for obtaining IP in one place.
-          first_interface = OVirtProvider::Util::Collection.find_matching(
-            server.interfaces, 'nic1')
-          ip_command = "#{config.ip_command} #{first_interface.mac}"
-
-          for i in 1..3
-            # Get IP address via ip_command.
-            ip_address = %x{#{ip_command}}
-            break if ip_address != ''
-            sleep 2
-          end
+          ip_address = server.ips.first
           if ip_address == nil or ip_address == ''
             raise Errors::NoIpAddressError
           end
@@ -55,7 +42,7 @@ module VagrantPlugins
           # Return the info
           # TODO: Some info should be configurable in Vagrantfile
           return {
-            :host             => ip_address.chomp!,
+            :host             => ip_address,
             :port             => machine.config.ssh.guest_port,
             :username         => machine.config.ssh.username,
             :private_key_path => machine.config.ssh.private_key_path,

--- a/lib/vagrant-ovirt/config.rb
+++ b/lib/vagrant-ovirt/config.rb
@@ -9,7 +9,6 @@ module VagrantPlugins
       attr_accessor :password
       attr_accessor :datacenter
       attr_accessor :cluster
-      attr_accessor :ip_command
 
       # Domain specific settings used while creating new machine.
       attr_accessor :memory
@@ -24,7 +23,6 @@ module VagrantPlugins
         @password       = UNSET_VALUE
         @datacenter     = UNSET_VALUE
         @cluster        = UNSET_VALUE
-        @ip_command     = UNSET_VALUE
 
         # Domain specific settings.
         @memory     = UNSET_VALUE
@@ -40,7 +38,6 @@ module VagrantPlugins
         @password = nil if @password == UNSET_VALUE
         @datacenter = nil if @datacenter == UNSET_VALUE
         @cluster = nil if @cluster == UNSET_VALUE
-        @ip_command = nil if @ip_command == UNSET_VALUE
 
         # Domain specific settings.
         @memory = 512 if @memory == UNSET_VALUE

--- a/tools/prepare_redhat_for_box.sh
+++ b/tools/prepare_redhat_for_box.sh
@@ -48,7 +48,7 @@ fi
 
 # Install some required software.
 yum -y install openssh-server openssh-clients sudo curl \
-ruby ruby-devel make gcc rubygems rsync nmap puppet
+ruby ruby-devel make gcc rubygems rsync puppet ovirt-guest-agent
 chkconfig sshd on
 
 # Users, groups, passwords and sudoers.
@@ -105,11 +105,6 @@ set_sysctl()
 set_sysctl 'net.ipv4.conf.all.arp_ignore' 1
 set_sysctl 'net.ipv4.conf.all.arp_announce' 2
 set_sysctl 'net.ipv4.conf.all.rp_filter' 3
-
-# Ok, this is not very clean solution. Should be replaced in future. It allows
-# all machines on local network to have arp record about new VM.
-echo 'for NETWORK in $(ip a | grep -w inet | grep -v "127.0.0.1" | awk "{ print \$2 }"); do nmap -sP $NETWORK; done' > /etc/rc3.d/S99ping_broadcast
-chmod +x /etc/rc3.d/S99ping_broadcast
 
 # Don't fix ethX names to hw address.
 rm -f /etc/udev/rules.d/*persistent-net.rules


### PR DESCRIPTION
This replaces the old nmap broadcast/arp hack which was
previously used to find out the guest IP address and also
allows the vagrant-ovirt plugin to be used from different
network subnets.

Requires https://github.com/fog/fog/pull/3162 and a box
image which contains the package 'ovirt-guest-agent'

I've added a dependency on fog version 1.24.0. This version
is not released yet, but I expect it to be the first future version
of fog which contains the required change. Feel free to wait
with approving this PR until the fog PR is accepted and a new
fog version has been released
