### PR TITLE
Allow network interface type to be specified

### DIFF
--- a/lib/vagrant-ovirt/action/create_network_interfaces.rb
+++ b/lib/vagrant-ovirt/action/create_network_interfaces.rb
@@ -40,7 +40,8 @@ module VagrantPlugins
             options = scoped_hash_override(options, :ovirt)
             options = {
               :netmask      => '255.255.255.0',
-              :network_name => 'rhevm'
+              :network_name => 'rhevm',
+              :interface_type => 'virtio'
             }.merge(options)
 
             if options[:adapter]
@@ -79,7 +80,7 @@ module VagrantPlugins
               machine.add_interface(
                 :name    => "nic#{iface_number}",
                 :network => network.id,
-                :interface => network.name,
+                :interface => opts[:interface_type],
               )
             rescue => e
               raise Errors::AddInterfaceError,


### PR DESCRIPTION
This change also fixes the following error on modern RHEV/oVirt environments:
ERROR vagrant: #<VagrantPlugins::OVirtProvider::Errors::AddInterfaceError: Error while adding new interface to VM. rhevm is not a member of NicInterface. Possible values for NicInterface are: e1000, virtio, rtl8139, rtl8139_virtio, spapr_vlan>
ERROR vagrant: Error while adding new interface to VM. rhevm is not a member of NicInterface. Possible values for NicInterface are: e1000, virtio, rtl8139, rtl8139_virtio, spapr_vlan
