### PR TITLE
Fixes ca_no_verify option, adds ca_cert_store and ca_cert_file options

### DIFF
--- a/lib/vagrant-ovirt3/action/connect_ovirt.rb
+++ b/lib/vagrant-ovirt3/action/connect_ovirt.rb
@@ -34,6 +34,8 @@ module VagrantPlugins
           conn_attr[:ovirt_username] = config.username if config.username
           conn_attr[:ovirt_password] = config.password if config.password
           conn_attr[:ovirt_ca_no_verify] = config.ca_no_verify if config.ca_no_verify
+          conn_attr[:ovirt_ca_cert_store] = config.ca_cert_store if config.ca_cert_store
+          conn_attr[:ovirt_ca_cert_file] = config.ca_cert_file if config.ca_cert_file
 
           # We need datacenter id in fog connection initialization. But it's
           # much simpler to use datacenter name in Vagrantfile. So get
@@ -76,7 +78,10 @@ module VagrantPlugins
             credentials[:ovirt_password],
             credentials[:ovirt_url],
             { :datacenter_id => credentials[:ovirt_datacenter],
-              :ca_no_verify => credentials[:ovirt_ca_no_verify] }
+              :ca_no_verify => credentials[:ovirt_ca_no_verify],
+              :ca_cert_store => credentials[:ovirt_ca_cert_store],
+              :ca_cert_file => credentials[:ovirt_ca_cert_file]
+            }
           )
         end
       end

--- a/lib/vagrant-ovirt3/config.rb
+++ b/lib/vagrant-ovirt3/config.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
       attr_accessor :console
       attr_accessor :disk_size
 
+      # TODO: change 'ca_cert_store' to 'ca_cert' once rbovirt PR #55 merges.
       attr_accessor :ca_no_verify
       attr_accessor :ca_cert_store
       attr_accessor :ca_cert_file

--- a/lib/vagrant-ovirt3/config.rb
+++ b/lib/vagrant-ovirt3/config.rb
@@ -17,6 +17,10 @@ module VagrantPlugins
       attr_accessor :console
       attr_accessor :disk_size
 
+      attr_accessor :ca_no_verify
+      attr_accessor :ca_cert_store
+      attr_accessor :ca_cert_file
+
       def initialize
         @url            = UNSET_VALUE
         @username       = UNSET_VALUE
@@ -32,6 +36,8 @@ module VagrantPlugins
         @disk_size  = UNSET_VALUE
 
         @ca_no_verify = UNSET_VALUE
+        @ca_cert_store = UNSET_VALUE
+        @ca_cert_file = UNSET_VALUE
       end
 
       def finalize!
@@ -49,6 +55,8 @@ module VagrantPlugins
         @disk_size = nil if @disk_size == UNSET_VALUE
 
         @ca_no_verify = false if @ca_no_verify == UNSET_VALUE
+        @ca_cert_store = nil if @ca_cert_store == UNSET_VALUE
+        @ca_cert_file = nil if @ca_cert_file == UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
The `ca_no_verify` option was not getting set, since there was no accessor in the `Config` class.  I added an accessor, and also added a couple more ca options that rbovirt supports.