### PR TITLE
Adds config option, `filtered_api`, which allows non-admin users to use backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,12 @@ This provider exposes quite a few provider-specific configuration options:
 * `password` - Password to access oVirt.
 * `datacenter` - oVirt datacenter name, where machines will be created.
 * `cluster` - oVirt cluster name. Defaults to first cluster found.
+* `filtered_api` - Set to `true` if oVirt user does not have admin priviliges.
 * `ca_no_verify` - Set to `true` to not verify TLS certificates.
+* `ca_cert_store` - Certificate authority store to use for verification (this
+  option will be replaced with `ca_cert` in a future version).
+* `ca_cert_file` - Like `ca_cert_store`, but provides a file containing a single
+  certificate.
 
 ### Domain Specific Options
 

--- a/lib/vagrant-ovirt3/action/connect_ovirt.rb
+++ b/lib/vagrant-ovirt3/action/connect_ovirt.rb
@@ -36,6 +36,7 @@ module VagrantPlugins
           conn_attr[:ovirt_ca_no_verify] = config.ca_no_verify if config.ca_no_verify
           conn_attr[:ovirt_ca_cert_store] = config.ca_cert_store if config.ca_cert_store
           conn_attr[:ovirt_ca_cert_file] = config.ca_cert_file if config.ca_cert_file
+          conn_attr[:ovirt_filtered_api] = config.filtered_api if config.filtered_api
 
           # We need datacenter id in fog connection initialization. But it's
           # much simpler to use datacenter name in Vagrantfile. So get
@@ -80,7 +81,8 @@ module VagrantPlugins
             { :datacenter_id => credentials[:ovirt_datacenter],
               :ca_no_verify => credentials[:ovirt_ca_no_verify],
               :ca_cert_store => credentials[:ovirt_ca_cert_store],
-              :ca_cert_file => credentials[:ovirt_ca_cert_file]
+              :ca_cert_file => credentials[:ovirt_ca_cert_file],
+              :filtered_api => credentials[:ovirt_filtered_api]
             }
           )
         end

--- a/lib/vagrant-ovirt3/config.rb
+++ b/lib/vagrant-ovirt3/config.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       attr_accessor :password
       attr_accessor :datacenter
       attr_accessor :cluster
+      attr_accessor :filtered_api
 
       # Domain specific settings used while creating new machine.
       attr_accessor :memory
@@ -28,6 +29,7 @@ module VagrantPlugins
         @password       = UNSET_VALUE
         @datacenter     = UNSET_VALUE
         @cluster        = UNSET_VALUE
+        @filtered_api   = UNSET_VALUE
 
         # Domain specific settings.
         @memory     = UNSET_VALUE
@@ -47,6 +49,7 @@ module VagrantPlugins
         @password = nil if @password == UNSET_VALUE
         @datacenter = nil if @datacenter == UNSET_VALUE
         @cluster = nil if @cluster == UNSET_VALUE
+        @filtered_api = false if @filtered_api == UNSET_VALUE
 
         # Domain specific settings.
         @memory = 512 if @memory == UNSET_VALUE


### PR DESCRIPTION
Another config option for you, which will allow regular oVirt users to use this plugin.  I'm getting a vagrant-ovirt workflow set up for use in my place-of-work.  I'm also planning on implementing more vagrant commands, such as `halt`.