### PR TITLE
Implements `halt`, `suspend`, and `resume` commands

### DIFF
--- a/lib/vagrant-ovirt3/action.rb
+++ b/lib/vagrant-ovirt3/action.rb
@@ -117,6 +117,7 @@ module VagrantPlugins
       def self.action_ssh
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
+          b.use ConnectOVirt
           b.use Call, ReadState do |env, b2|
             if env[:machine_state_id] == :not_created
               b2.use MessageNotCreated

--- a/lib/vagrant-ovirt3/action.rb
+++ b/lib/vagrant-ovirt3/action.rb
@@ -11,22 +11,23 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
           b.use ConnectOVirt
-          b.use Call, IsCreated do |env, b2|
-            if env[:result]
-              b2.use StartVM
-              b2.use WaitTillUp
-              b2.use SyncFolders
+          b.use Call, ReadState do |env, b2|
+            if env[:machine_state_id] == :up
+              b2.use MessageAlreadyUp
               next
             end
 
-            b2.use SetNameOfDomain
-            b2.use CreateVM
-            b2.use ResizeDisk
+            if env[:machine_state_id] == :not_created
+              b2.use SetNameOfDomain
+              b2.use CreateVM
+              b2.use ResizeDisk
 
-            b2.use Provision
-            b2.use CreateNetworkInterfaces
+              b2.use Provision
+              b2.use CreateNetworkInterfaces
 
-            b2.use SetHostname
+              b2.use SetHostname
+            end
+
             b2.use StartVM
             b2.use WaitTillUp
             b2.use SyncFolders
@@ -149,6 +150,7 @@ module VagrantPlugins
       autoload :WaitTillUp, action_root.join("wait_till_up")
       autoload :SyncFolders, action_root.join("sync_folders")
       autoload :MessageAlreadyCreated, action_root.join("message_already_created")
+      autoload :MessageAlreadyUp, action_root.join("message_already_up")
 
       private
       def self.with_ovirt

--- a/lib/vagrant-ovirt3/action/halt_vm.rb
+++ b/lib/vagrant-ovirt3/action/halt_vm.rb
@@ -1,0 +1,23 @@
+require 'log4r'
+
+module VagrantPlugins
+  module OVirtProvider
+    module Action
+      class HaltVM
+        def initialize(app, env)
+          @logger = Log4r::Logger.new("vagrant_ovirt3::action::halt_vm")
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info(I18n.t("vagrant_ovirt3.halt_vm"))
+
+          machine = env[:ovirt_compute].servers.get(env[:machine].id.to_s)
+          machine.stop
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ovirt3/action/message_already_up.rb
+++ b/lib/vagrant-ovirt3/action/message_already_up.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module OVirtProvider
+    module Action
+      class MessageAlreadyUp
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info(I18n.t("vagrant_ovirt3.already_up"))
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ovirt3/action/message_not_suspended.rb
+++ b/lib/vagrant-ovirt3/action/message_not_suspended.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module OVirtProvider
+    module Action
+      class MessageNotSuspended
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info(I18n.t("vagrant_ovirt3.not_suspended"))
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ovirt3/action/message_not_up.rb
+++ b/lib/vagrant-ovirt3/action/message_not_up.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module OVirtProvider
+    module Action
+      class MessageNotUp
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info(I18n.t("vagrant_ovirt3.not_up"))
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ovirt3/action/message_saving_state.rb
+++ b/lib/vagrant-ovirt3/action/message_saving_state.rb
@@ -1,0 +1,16 @@
+module VagrantPlugins
+  module OVirtProvider
+    module Action
+      class MessageSavingState
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info(I18n.t("vagrant_ovirt3.saving_state"))
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-ovirt3/action/read_state.rb
+++ b/lib/vagrant-ovirt3/action/read_state.rb
@@ -16,6 +16,8 @@ module VagrantPlugins
           @app.call(env)
         end
 
+        # Possible states include (but may not be limited to):
+        # :not_created, :up, :down, :saving_state, :suspended
         def read_state(ovirt, machine)
           return :not_created if machine.id.nil?
 
@@ -27,7 +29,7 @@ module VagrantPlugins
           end
 
           # Return the state
-          return server.status
+          return server.status.to_sym
         end
       end
     end

--- a/lib/vagrant-ovirt3/action/read_state.rb
+++ b/lib/vagrant-ovirt3/action/read_state.rb
@@ -21,9 +21,7 @@ module VagrantPlugins
 
           # Find the machine
           server = ovirt.servers.get(machine.id)
-          if server.nil? || [:"shutting-down", :terminated].include?(server.status.to_sym)
-            # The machine can't be found
-            @logger.info("Machine not found or terminated, assuming it got destroyed.")
+          if server.nil?
             machine.id = nil
             return :not_created
           end

--- a/lib/vagrant-ovirt3/action/suspend_vm.rb
+++ b/lib/vagrant-ovirt3/action/suspend_vm.rb
@@ -1,0 +1,24 @@
+require 'log4r'
+
+module VagrantPlugins
+  module OVirtProvider
+    module Action
+      class SuspendVM
+        def initialize(app, env)
+          @logger = Log4r::Logger.new("vagrant_ovirt3::action::suspend_vm")
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info(I18n.t("vagrant_ovirt3.suspend_vm"))
+
+          machine = env[:ovirt_compute].servers.get(env[:machine].id.to_s)
+          machine.suspend
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end
+

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,8 @@ en:
       Removing VM...
     not_created: |-
       VM is not created. Please run `vagrant up` first.
+    not_up: |-
+      VM is not running. Please run `vagrant up` first.
     starting_vm: |-
       Starting VM.
     suspend_vm: |-
@@ -30,6 +32,10 @@ en:
       Machine is booted and ready for use!
     wait_for_ready_volume: |-
       Waiting for VM volume to become "ready" to start...
+    saving_state: |-
+      VM is busy saving state. Please wait and try again.
+    not_suspended: |-
+      VM is not in a suspended state.
 
     errors:
       fog_ovirt_connection_error: |-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -24,6 +24,8 @@ en:
       Waiting for VM to become "ready" to start...
     already_created: |-
       VM is already created.
+    already_up: |-
+      VM is already up.
     ready: |-
       Machine is booted and ready for use!
     wait_for_ready_volume: |-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,6 +8,10 @@ en:
       VM is not created. Please run `vagrant up` first.
     starting_vm: |-
       Starting VM.
+    suspend_vm: |-
+      Suspending VM...
+    halt_vm: |-
+      Halting VM...
     error_recovering: |-
       An error occured. Recovering..
     waiting_for_ip: |-


### PR DESCRIPTION
I get an error when running suspend command due to the fact that rbovirt apparently does not handle results for asynchronous actions.  The command works - you just get a stack trace instead of a success message.  I may send a pull request to rbovirt.