### PR TITLE
Adds config option, `template_version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This provider exposes quite a few provider-specific configuration options:
 * `memory` - Amount of memory in MBytes. Defaults to 512 if not set.
 * `cpus` - Number of virtual cpus. Defaults to 1 if not set.
 * `template` - Name of template from which new VM should be created.
+* `template_version` - If a template has sub-versions, specify a sub-version
+ number or name.
 * `console` - Console type to use. Can be 'vnc' or 'spice'. Default is 'spice'
 * `disk_size` - If set, the first volume of the VM will automatically be resized
  to the specified value. disk_size is in GB

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -47,17 +47,20 @@ module VagrantPlugins
             raise Error::NoTemplateError,
               :template_name => config.template
           end
+          ver = template.raw.version
+          if !ver.version_name.nil? and !ver.version_name.empty?
+            version_string = "#{ver.version_name} (#{ver.version_number.to_i})"
+          else
+            version_string = "#{ver.version_number.to_i}"
+          end
 
           # Output the settings we're going to use to the user
-          ver = template.raw.version
           env[:ui].info(I18n.t("vagrant_ovirt3.creating_vm"))
           env[:ui].info(" -- Name:          #{name}")
           env[:ui].info(" -- Cpus:          #{cpus}")
           env[:ui].info(" -- Memory:        #{memory_size/1024}M")
           env[:ui].info(" -- Template:      #{template.name}")
-          if ver.version_name or ver.version_number
-            env[:ui].info(" -- Version:       #{ver.version_name || ver.version_number}")
-          end
+          env[:ui].info(" -- Version:       #{version_string}")
           env[:ui].info(" -- Datacenter:    #{config.datacenter}")
           env[:ui].info(" -- Cluster:       #{cluster.name}")
           env[:ui].info(" -- Console:       #{console}")

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -34,8 +34,13 @@ module VagrantPlugins
           env[:ovirt_cluster] = cluster
 
           # Get template
-          template = OVirtProvider::Util::Collection.find_matching(
-            env[:ovirt_compute].templates.all, config.template)
+          template = env[:ovirt_compute].templates.all.find { |t|
+            v = t.raw.version
+            cv = config.template_version
+            t.id == config.template or
+              (t.name == config.template and
+               (cv.nil? or (cv == v.version_number or cv == v.version_name)))
+          }
           if template == nil
             raise Error::NoTemplateError,
               :template_name => config.template

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -34,12 +34,14 @@ module VagrantPlugins
           env[:ovirt_cluster] = cluster
 
           # Get template
-          template = env[:ovirt_compute].templates.all.find { |t|
+          template = env[:ovirt_compute].templates.all.find_all { |t|
+            t.id == config.template or t.name == config.template
+          }
+          .sort_by { |t| t.raw.version.version_number.to_i }.reverse
+          .find { |t|
             v = t.raw.version
             cv = config.template_version
-            t.id == config.template or
-              (t.name == config.template and
-               (cv.nil? or (cv == v.version_number or cv == v.version_name)))
+            cv.nil? or (cv.to_i == v.version_number.to_i or cv == v.version_name)
           }
           if template == nil
             raise Error::NoTemplateError,

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -49,11 +49,15 @@ module VagrantPlugins
           end
 
           # Output the settings we're going to use to the user
+          ver = template.raw.version
           env[:ui].info(I18n.t("vagrant_ovirt3.creating_vm"))
           env[:ui].info(" -- Name:          #{name}")
           env[:ui].info(" -- Cpus:          #{cpus}")
           env[:ui].info(" -- Memory:        #{memory_size/1024}M")
           env[:ui].info(" -- Template:      #{template.name}")
+          if ver.version_name or ver.version_number
+            env[:ui].info(" -- Version:       #{ver.version_name || ver.version_number}")
+          end
           env[:ui].info(" -- Datacenter:    #{config.datacenter}")
           env[:ui].info(" -- Cluster:       #{cluster.name}")
           env[:ui].info(" -- Console:       #{console}")

--- a/lib/vagrant-ovirt3/config.rb
+++ b/lib/vagrant-ovirt3/config.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :memory
       attr_accessor :cpus
       attr_accessor :template
+      attr_accessor :template_version
       attr_accessor :console
       attr_accessor :disk_size
 
@@ -35,6 +36,7 @@ module VagrantPlugins
         @memory     = UNSET_VALUE
         @cpus       = UNSET_VALUE
         @template   = UNSET_VALUE
+        @template_version = UNSET_VALUE
         @console    = UNSET_VALUE
         @disk_size  = UNSET_VALUE
 
@@ -55,6 +57,7 @@ module VagrantPlugins
         @memory = 512 if @memory == UNSET_VALUE
         @cpus = 1 if @cpus == UNSET_VALUE
         @template = 'Blank' if @template == UNSET_VALUE
+        @template_version = nil if @template_version == UNSET_VALUE
         @console = 'spice' if @console == UNSET_VALUE
         @disk_size = nil if @disk_size == UNSET_VALUE
 


### PR DESCRIPTION
This change adds a config option to specify which template version to use when creating a vm, in case there are multiple template versions for the same name.  The version may be a name or a number.  (Each template version has a number and an optional version name, which is distinct from the template name).

I also changed template selection in the case where no version is specified to select the most recent version.

Before this change it was difficult to predict which template would be used if a name was specified (as opposed to an id).  The choice would depend on which template is listed first in the template list API call.

Specifying a template by id is the most precise option - but I was not able to find template ids through OVirt's user portal UI.  So I thought that it would be useful to allow configuration using parameters that are easy to look up in the UI. 

