### PR TITLE
Adds config option, `user_data`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ This provider exposes quite a few provider-specific configuration options:
 * `console` - Console type to use. Can be 'vnc' or 'spice'. Default is 'spice'
 * `disk_size` - If set, the first volume of the VM will automatically be resized
  to the specified value. disk_size is in GB
+* `user_data` - If given, user data is made available to the VM via a virtual
+ floppy disk.  This data is used to configure VMs via cloud-init. The value for
+ `user_data` should generally be a string in [cloud-config format][].
+
+[cloud-config format]: https://cloudinit.readthedocs.org/en/latest/topics/examples.html
 
 Specific domain settings can be set for each domain separately in multi-VM
 environment. Example below shows a part of Vagrantfile, where specific options

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -21,6 +21,9 @@ module VagrantPlugins
           console = config.console
           cpus = config.cpus
           memory_size = config.memory*1024
+          user_data = config.user_data ?
+            Base64::encode64(config.user_data) :
+            nil
 
           # Get cluster
           if config.cluster == nil
@@ -53,6 +56,9 @@ module VagrantPlugins
           if config.disk_size
             env[:ui].info(" -- Disk size:     #{config.disk_size}G")
           end
+          if config.user_data
+            env[:ui].info(" -- User data:\n#{config.user_data}")
+          end
 
           # Create oVirt VM.
           attr = {
@@ -62,6 +68,7 @@ module VagrantPlugins
               :cluster  => cluster.id,
               :template => template.id,
               :display  => {:type => console },
+              :user_data => user_data,
           }
 
           begin

--- a/lib/vagrant-ovirt3/config.rb
+++ b/lib/vagrant-ovirt3/config.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
       attr_accessor :template
       attr_accessor :console
       attr_accessor :disk_size
+      attr_accessor :user_data
 
       # TODO: change 'ca_cert_store' to 'ca_cert' once rbovirt PR #55 merges.
       attr_accessor :ca_no_verify
@@ -37,6 +38,7 @@ module VagrantPlugins
         @template   = UNSET_VALUE
         @console    = UNSET_VALUE
         @disk_size  = UNSET_VALUE
+        @user_data  = UNSET_VALUE
 
         @ca_no_verify = UNSET_VALUE
         @ca_cert_store = UNSET_VALUE
@@ -57,6 +59,7 @@ module VagrantPlugins
         @template = 'Blank' if @template == UNSET_VALUE
         @console = 'spice' if @console == UNSET_VALUE
         @disk_size = nil if @disk_size == UNSET_VALUE
+        @user_data = nil if @user_data == UNSET_VALUE
 
         @ca_no_verify = false if @ca_no_verify == UNSET_VALUE
         @ca_cert_store = nil if @ca_cert_store == UNSET_VALUE


### PR DESCRIPTION
Yet another pull request - getting close to the end though.

If given, user data is made available to the VM via a virtual floppy disk.  This data is used to configure VMs via cloud-init.

The value for user_data should generally be a string in YAML format, as described at:
https://cloudinit.readthedocs.org/en/latest/topics/examples.html
