### PR TITLE
Add nic_mac_addresses capability.

### DIFF
--- a/lib/vagrant-ovirt3/cap/nic_mac_addresses.rb
+++ b/lib/vagrant-ovirt3/cap/nic_mac_addresses.rb
@@ -1,0 +1,15 @@
+# vim: ai ts=2 sts=2 et sw=2 ft=ruby
+module VagrantPlugins
+  module OVirtProvider
+    module Cap
+      module NicMacAddresses
+        def self.nic_mac_addresses(machine)
+          ovirt = OVirtProvider.ovirt_connection
+          interfaces = ovirt.list_vm_interfaces(machine.id.to_s)
+          Hash[interfaces.map{ |i| [i[:name], i[:mac]] }]
+        end
+      end
+    end
+  end
+end
+

--- a/lib/vagrant-ovirt3/plugin.rb
+++ b/lib/vagrant-ovirt3/plugin.rb
@@ -1,3 +1,4 @@
+# vim: ai ts=2 sts=2 et sw=2 ft=ruby
 begin
   require 'vagrant'
 rescue LoadError
@@ -31,6 +32,11 @@ module VagrantPlugins
 
         require_relative "provider"
         Provider
+      end
+
+      provider_capability("ovirt3", :nic_mac_addresses) do
+        require_relative "cap/nic_mac_addresses"
+        Cap::NicMacAddresses
       end
 
       # This initializes the internationalization strings.


### PR DESCRIPTION
Fix https://github.com/myoung34/vagrant-ovirt3/issues/32

It seems when I do a `vagrant up`, Vagrant gets the list of interfaces using the capability, but doesn't do anything with it. There's no error, and the VM comes up so I'm opening this PR. I'm mentioning this because it's possible that the NIC-MAC hash I return isn't correct, but my local, manual testing isn't catching it.