### PR TITLE
Make sure domain name doesn't exceed the max length

### DIFF
--- a/lib/vagrant-ovirt3/action/set_name_of_domain.rb
+++ b/lib/vagrant-ovirt3/action/set_name_of_domain.rb
@@ -4,14 +4,16 @@ module VagrantPlugins
 
       # Setup name for domain and domain volumes.
       class SetNameOfDomain
+        @@MAX_NAME_LENGTH = 64
         def initialize(app, env)
           @app = app
         end
 
         def call(env)
-          env[:domain_name] = env[:root_path].basename.to_s.dup
-          env[:domain_name].gsub!(/[^-a-z0-9_]/i, "")
-          env[:domain_name] << "_#{Time.now.to_f}"
+          dir_name = env[:root_path].basename.to_s.dup.gsub(/[^-a-z0-9_]/i, "")
+          timestamp = "_#{Time.now.to_f}"
+          max_dir_name_length = dir_name.length-[(dir_name + timestamp).length-(@@MAX_NAME_LENGTH-1), 0].max
+          env[:domain_name] = dir_name[0..max_dir_name_length] << timestamp
 
           # Check if the domain name is not already taken
           domain = OVirtProvider::Util::Collection.find_matching(


### PR DESCRIPTION
Shorten the root path base name part if the full domain name exceeded the max length.