### PR TITLE
Unset default values for CPU and memory.

### DIFF
--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
           name = env[:domain_name]
           console = config.console
           cpus = config.cpus
-          memory_size = config.memory*1024
+          memory_size = config.memory
           user_data = config.user_data ?
             Base64::encode64(config.user_data) :
             nil
@@ -60,8 +60,12 @@ module VagrantPlugins
           # Output the settings we're going to use to the user
           env[:ui].info(I18n.t("vagrant_ovirt3.creating_vm"))
           env[:ui].info(" -- Name:          #{name}")
-          env[:ui].info(" -- Cpus:          #{cpus}")
-          env[:ui].info(" -- Memory:        #{memory_size/1024}M")
+          if cpus != Vagrant::Plugin::V2::Config::UNSET_VALUE
+            env[:ui].info(" -- Cpus:          #{cpus}")
+          end
+          if memory_size != Vagrant::Plugin::V2::Config::UNSET_VALUE
+            env[:ui].info(" -- Memory:        #{memory_size}")
+          end
           env[:ui].info(" -- Template:      #{template.name}")
           env[:ui].info(" -- Version:       #{version_string}")
           env[:ui].info(" -- Datacenter:    #{config.datacenter}")
@@ -77,13 +81,18 @@ module VagrantPlugins
           # Create oVirt VM.
           attr = {
               :name     => name,
-              :cores    => cpus,
-              :memory   => memory_size*1024,
               :cluster  => cluster.id,
               :template => template.id,
               :display  => {:type => console },
               :user_data => user_data,
           }
+
+          if cpus != Vagrant::Plugin::V2::Config::UNSET_VALUE
+              attr[:cores] = cpus
+          end
+          if memory_size != Vagrant::Plugin::V2::Config::UNSET_VALUE
+              attr[:memory] = memory_size*1024*1024
+          end
 
           begin
             server = env[:ovirt_compute].servers.create(attr)

--- a/lib/vagrant-ovirt3/config.rb
+++ b/lib/vagrant-ovirt3/config.rb
@@ -56,8 +56,8 @@ module VagrantPlugins
         @filtered_api = false if @filtered_api == UNSET_VALUE
 
         # Domain specific settings.
-        @memory = 512 if @memory == UNSET_VALUE
-        @cpus = 1 if @cpus == UNSET_VALUE
+        #@memory = 512 if @memory == UNSET_VALUE
+        #@cpus = 1 if @cpus == UNSET_VALUE
         @template = 'Blank' if @template == UNSET_VALUE
         @template_version = nil if @template_version == UNSET_VALUE
         @console = 'spice' if @console == UNSET_VALUE


### PR DESCRIPTION
Fix for https://github.com/myoung34/vagrant-ovirt3/issues/39

Do not set default values for CPU and memory if missing from configuration.