### PR TITLE
Fix "VM is locked" error when creating & "VM is running" when destroying

### DIFF
--- a/lib/vagrant-ovirt3/action.rb
+++ b/lib/vagrant-ovirt3/action.rb
@@ -89,6 +89,8 @@ module VagrantPlugins
             end
 
             b2.use ConnectOVirt
+            b2.use HaltVM
+            b2.use WaitTillDown
             b2.use DestroyVM
           end
         end
@@ -179,6 +181,7 @@ module VagrantPlugins
       autoload :ReadState, action_root.join("read_state")
       autoload :ReadSSHInfo, action_root.join("read_ssh_info")
       autoload :WaitTillUp, action_root.join("wait_till_up")
+      autoload :WaitTillDown, action_root.join("wait_till_down")
       autoload :SyncFolders, action_root.join("sync_folders")
       autoload :MessageAlreadyCreated, action_root.join("message_already_created")
       autoload :MessageAlreadyUp, action_root.join("message_already_up")

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -97,17 +97,21 @@ module VagrantPlugins
 
           # Wait till all volumes are ready.
           env[:ui].info(I18n.t("vagrant_ovirt3.wait_for_ready_vm"))
-          for i in 0..10
-            ready = true
-            server = env[:ovirt_compute].servers.get(env[:machine].id.to_s)
-            server.volumes.each do |volume|
-              if volume.status != 'ok'
-                ready = false
-                break
-              end
-            end
-            break if ready
-            sleep 2
+          for i in 0..20
+             ready = true
+             server = env[:ovirt_compute].servers.get(env[:machine].id.to_s)
+             server.volumes.each do |volume|
+               if volume.status != 'ok'
+                 ready = false
+                 break
+               end
+             end
+             if server.status != 'down'
+               env[:ui].info(server.status)
+               ready = false
+             end
+             break if ready
+             sleep 2
           end
 
           if not ready

--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -107,7 +107,6 @@ module VagrantPlugins
                end
              end
              if server.status != 'down'
-               env[:ui].info(server.status)
                ready = false
              end
              break if ready

--- a/lib/vagrant-ovirt3/action/wait_till_down.rb
+++ b/lib/vagrant-ovirt3/action/wait_till_down.rb
@@ -6,22 +6,21 @@ module VagrantPlugins
   module OVirtProvider
     module Action
 
-      # Wait till VM is started, till it obtains an IP address and is
-      # accessible via ssh.
+      # Wait till VM is stopped
       class WaitTillDown
         include Vagrant::Util::Retryable
 
         def initialize(app, env)
-          @logger = Log4r::Logger.new("vagrant_ovirt3::action::wait_till_up")
+          @logger = Log4r::Logger.new("vagrant_ovirt3::action::wait_till_down")
           @app = app
         end
 
         def call(env)
 
+          env[:ui].info(I18n.t("vagrant_ovirt3.wait_till_down"))
           for i in 0..20
             ready = true
             server = env[:ovirt_compute].servers.get(env[:machine].id.to_s)
-            env[:ui].info(server.status)
             if server.status != 'down'
               ready = false
             end
@@ -30,7 +29,7 @@ module VagrantPlugins
           end
 
           if not ready
-            raise Errors::WaitForReadyVmTimeout
+            raise Errors::WaitForShutdownVmTimeout
           end
 
           

--- a/lib/vagrant-ovirt3/errors.rb
+++ b/lib/vagrant-ovirt3/errors.rb
@@ -59,6 +59,10 @@ module VagrantPlugins
         error_key(:wait_for_ready_vm_timeout)
       end
 
+      class WaitForShutdownVmTimeout < VagrantOVirtError
+        error_key(:wait_for_shutdown_vm_timeout)
+      end
+
       class NoIpAddressError < VagrantOVirtError
         error_key(:no_ip_address_error)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,6 +16,8 @@ en:
       Halting VM...
     error_recovering: |-
       An error occured. Recovering..
+    wait_till_down: |-
+      Waiting for VM to shutdown...
     waiting_for_ip: |-
       Waiting for VM to get an IP address...
     waiting_for_ssh: |-
@@ -81,7 +83,9 @@ en:
         Error while updating volume. %{error_message}
       wait_for_ready_resized_volume_timeout: |-
         Timeout occurred while waiting for resized volume to become ready
-
+      wait_for_shutdown_vm_timeout: |-
+        Timeout occurred while waiting for VM to shutdown
+ 
     states:
       short_paused: |-
         pause


### PR DESCRIPTION
Hi,

In our oVirt environment, we had an issue when creating a VM from a template: waiting for volume to have status='ok' was not enough to be able to start the VM. 
So, a new test on server.status was added to be sure VM is ready to start.

I think it would be possible to remove volume.status test loop, but I don't want to break compatibility.