### PR TITLE
Fix "VM is locked" error during creation

### DIFF
--- a/lib/vagrant-ovirt3/action/create_vm.rb
+++ b/lib/vagrant-ovirt3/action/create_vm.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           config = env[:machine].provider_config
 
           # Gather some info about domain
-          name = (config.name.nil? ? env[:domain_name] : config.name)[0,15]
+          name = (config.name.nil? ? env[:domain_name] : config.name)[0,80]
           console = config.console
           cpus = config.cpus
           memory_guaranteed_size = config.memory_guaranteed ? config.memory_guaranteed*1024 : nil
@@ -116,6 +116,9 @@ module VagrantPlugins
                 ready = false
                 break
               end
+            end
+            if env[:machine].state.id != :down
+              ready = false
             end
             break if ready
             sleep 2


### PR DESCRIPTION
Hi,

A new PR to fix "VM is locked" error when creating a VM.
Testing volume status is not enough to declare VM as ready to be started.